### PR TITLE
Fix install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ storage foundation for a Free Internet!
 If you have [Go](https://golang.org/cmd/go/) installed you can run:
 
 ```
-go get -u github.com/NebulousLabs/skynet-cli...
+go get -u github.com/NebulousLabs/skynet-cli/cmd...
 ```
 
 or you can pull the appropriate binary from our [Releases](https://github.com/NebulousLabs/skynet-cli/releases) page,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ storage foundation for a Free Internet!
 If you have [Go](https://golang.org/cmd/go/) installed you can run:
 
 ```
-go get -u github.com/NebulousLabs/skynet-cli/cmd...
+go get -u github.com/NebulousLabs/skynet-cli/...
 ```
 
 or you can pull the appropriate binary from our [Releases](https://github.com/NebulousLabs/skynet-cli/releases) page,


### PR DESCRIPTION
Fixes the install instructions. Seems like other projects just include `cmd` in the command, e.g. https://github.com/prometheus/prometheus

cc @ro-tex (not able to assign on the PR)